### PR TITLE
add for build/icons

### DIFF
--- a/dev-env/lib/make_manifest.js
+++ b/dev-env/lib/make_manifest.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs-extra';
 import path from 'path';
 import packageConfig from '../../package.json';
 import manifestSkelet from '../../src/manifest.json';
@@ -161,6 +161,15 @@ export default function() {
     overrides.newtab && procesHtmlPage(overrides.newtab)
   }
 
+    // create icons folder if icons specified in manifest.json
+    if (manifest.icons && Object.keys(manifest.icons).length) {
+      console.log(clc.green(`Making 'build/icons'`))
+      const sourceIconsPath = path.resolve(path.join('src', 'icons'));
+      const destIconsPath = path.join(buildPath, "icons");
+      // copies whole icons folder, sync method doesn't need callback
+      fs.copySync(sourceIconsPath, destIconsPath);
+
+    }
 
 
   // Writing build/manifest.json

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cli-color": "^1.0.0",
     "css-loader": "^0.15.5",
     "file-loader": "^0.8.4",
+    "fs-extra": "^0.24.0",
     "gulp": "^3.9.0",
     "gulp-bg": "0.0.5",
     "gulp-eslint": "^0.15.0",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,5 +21,10 @@
   "permissions": [
     "background",
     "tabs"
-  ]
+  ],
+  "icons": {
+    "16": "icons/webpack-16.png",
+    "32": "icons/webpack-32.png",
+    "128": "icons/webpack-128.png"
+  }
 }


### PR DESCRIPTION
according to https://developer.chrome.com/extensions/manifest/icons
icons should be specified in `manifest.json`
and currently it can't be specified because it will be ignored in build process
