### PR TITLE
Fix incorrect URL in production mode

### DIFF
--- a/dev-env/lib/make_manifest.js
+++ b/dev-env/lib/make_manifest.js
@@ -121,7 +121,7 @@ export default function() {
 
     const scriptFilepath = `${bareFilepath}.js`
 
-    const webpackScriptUrl = process.env.NODE_ENV == "development" ? path.join("https://localhost:3001/", scriptFilepath) : scriptFilepath
+    const webpackScriptUrl = process.env.NODE_ENV == "development" ? path.join("https://localhost:3001/", scriptFilepath) : Remove.path(scriptFilepath)
     const webpackScript = `<script src="${webpackScriptUrl}" async defer></script>`;
 
     pushScriptName(scriptFilepath)


### PR DESCRIPTION
Currently, `webpackScriptURL` is a direct copy of the index.html URL. This causes an error when building for production, as shown below:
1. popup/index.html yields a `webpackScriptURL` of `popup/index.js`
2. We inject `<script src="popup/index.js" async defer></script>`
3. We get an error because the relative script path from `popup/index.html` is `index.js`, not `popup/index.js` (we don't have two nested popup directories)

This change addresses the issue by calling `Remove.path` on `webpackScriptURL` when `NODE_ENV` is 'production', giving us the correct relative URL to `index.js`.
