### PR TITLE
Solves unmet dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "url-loader": "^0.5.6",
     "webpack": "1.10.1",
     "webpack-dev-server": "1.10.1",
-    "yargs": "^3.15.0"
+    "yargs": "^3.15.0",
+    "node-libs-browser": ">=0.4.0"
   },
   "devDependencies": {
     "chokidar": "^1.0.5"


### PR DESCRIPTION
Solves the issue encountered while doing an `npm install`:

```
npm WARN EPEERINVALID webpack@1.10.1 requires a peer of node-libs-browser@>= 0.4.0 <=0.6.0 but none was installed.
```
