### PR TITLE
Fix for running on windows

### DIFF
--- a/dev-env/manifest/processor/assets.js
+++ b/dev-env/manifest/processor/assets.js
@@ -31,7 +31,7 @@ const processAsset = function(object, key, buildPath) {
 
   fs.copySync(assetSrcPath, assetDestPath)
 
-  object[key] = buildAssetPath
+  object[key] = buildAssetPath.replace(/\\/g,"/")
 
   log.done(`Done`)
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "private": true,
   "scripts": {
     "start": "npm run dev",
-    "dev": "NODE_ENV=development ./node_modules/.bin/babel-node ./dev-env/dev.js",
-    "build": "NODE_ENV=production ./node_modules/.bin/babel-node ./dev-env/build.js"
+    "dev": "cross-env NODE_ENV=development babel-node ./dev-env/dev.js",
+    "build": "cross-env NODE_ENV=production babel-node ./dev-env/build.js"
   },
   "keywords": [
     "chrome",
@@ -33,6 +33,7 @@
     "babel-preset-react-hmre": "1.0.1",
     "chokidar": "1.4.2",
     "cli-color": "1.1.0",
+    "cross-env": "^1.0.7",
     "css-loader": "0.23.1",
     "express": "4.13.4",
     "file-loader": "0.8.5",


### PR DESCRIPTION
Changed path separator in util/remove.js
Added Dev-dependency on cross-env to allow npm run scripts to set
Environment variables.
