### PR TITLE
Removed deprecated loggings in console

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "fs-extra": "0.26.5",
     "json-loader": "0.5.4",
     "lodash": "4.1.0",
-    "style-loader": "0.13.0",
+    "style-loader": "0.13.1",
     "url-loader": "0.5.7",
-    "webpack": "1.12.2",
-    "webpack-dev-server": "1.12.1"
+    "webpack": "1.13.1",
+    "webpack-dev-server": "1.14.1"
   }
 }


### PR DESCRIPTION
Info loggings for deprecated configurations has been exploding the console (check the image). Updating dependencies will remove those loggings.

Ref: https://github.com/petehunt/rwb/issues/27

![screen shot 2016-06-01 at 10 47 40 am](https://cloud.githubusercontent.com/assets/623060/15714159/70d2d5fe-27e7-11e6-8b29-d8f5a36d4654.png)
